### PR TITLE
Add ColorScheme to make it easier to find valid color schemes.

### DIFF
--- a/chord/__init__.py
+++ b/chord/__init__.py
@@ -19,6 +19,29 @@ mako.runtime.UNDEFINED = ""
 
 
 class ColorScheme:
+    categorical = (
+        "Category10", "Accent", "Dark2", "Paired",
+        "Pastel1", "Pastel2", "Set1", "Set2", "Set3",
+        "Tableau10"
+    )
+
+    diverging = (
+        "BrBG", "PRGn", "PiYG", "PuOr",
+        "RdBu", "RdGy", "RdYlBu", "RdYlGn",
+        "Spectral"
+    )
+
+    sequential = (
+        "Blues", "Greens", "Greys", "Oranges",
+        "Purples", "Reds"
+    )
+
+    sequential_multi_hue = (
+        "BuGn", "BuPu", "GnBu", "OrRd",
+        "PuBuGn", "PuBu", "PuRd", "RdPu",
+        "YlGnBu", "YlGn", "YlOrBr", "YlOrRd"
+    )
+
     # Categorical
     Category10 = "d3.schemeCategory10"
     Accent = "d3.schemeAccent"
@@ -64,18 +87,35 @@ class ColorScheme:
     YlOrBr = "d3.schemeYlOrBr"
     YlOrRd = "d3.schemeYlOrRd"
 
-    def __init__(self, val):
-        exclude = (
-            "Category10", "Accent", "Dark2", "Paired",
-            "Pastel1", "Pastel2", "Set1", "Set2", "Set3",
-            "Tableau10"
-        )
+    def __init__(self, k):
+        self.k = k if isinstance(k, int) else len(k)
 
-        num = val if isinstance(val, int) else len(val)
+    def __getattribute__(self, item):
+        val = object.__getattribute__(self, item)
+        categorical = object.__getattribute__(self, "categorical")
 
-        for attr, val in self.__dict__.items():
-            if not attr.startswith("__") and attr not in exclude:
-                self.__dict__[attr] = f"{val}[{num}]"
+        if item.startswith("__") or item in categorical:
+            return val
+
+        if isinstance(val, tuple):
+            return val
+
+        k = object.__getattribute__(self, "k")
+
+        if item in object.__getattribute__(self, "diverging"):
+            if 3 <= k <= 11:
+                return f"{val}[{k}]"
+            raise AttributeError(f"{val} requires 3 <= k <= 11 (got {k})")
+
+        if item in object.__getattribute__(self, "sequential"):
+            if 3 <= k <= 9:
+                return f"{val}[{k}]"
+            raise AttributeError(f"{val} requires 3 <= k <= 11 (got {k})")
+
+        if item in object.__getattribute__(self, "sequential_multi_hue"):
+            if 3 <= k <= 9:
+                return f"{val}[{k}]"
+            raise AttributeError(f"{val} requires 3 <= k <= 11 (got {k})")
 
 
 class Chord:

--- a/chord/__init__.py
+++ b/chord/__init__.py
@@ -18,7 +18,67 @@ import uuid
 mako.runtime.UNDEFINED = ""
 
 
-class Chord(object):
+class ColorScheme:
+    # Categorical
+    Category10 = "d3.schemeCategory10"
+    Accent = "d3.schemeAccent"
+    Dark2 = "d3.schemeDark2"
+    Paired = "d3.schemePaired"
+    Pastel1 = "d3.schemePastel1"
+    Pastel2 = "d3.schemePastel2"
+    Set1 = "d3.schemeSet1"
+    Set2 = "d3.schemeSet2"
+    Set3 = "d3.schemeSet3"
+    Tableau10 = "d3.schemeTableau10"
+
+    # Diverging
+    BrBG = "d3.schemeBrBG"
+    PRGn = "d3.schemePRGn"
+    PiYG = "d3.schemePiYG"
+    PuOr = "d3.schemePuOr"
+    RdBu = "d3.schemeRdBu"
+    RdGy = "d3.schemeRdGy"
+    RdYlBu = "d3.schemeRdYlBu"
+    RdYlGn = "d3.schemeRdYlGn"
+    Spectral = "d3.schemeSpectral"
+
+    # Sequential
+    Blues = "d3.schemeBlues"
+    Greens = "d3.schemeGreens"
+    Greys = "d3.schemeGreys"
+    Oranges = "d3.schemeOranges"
+    Purples = "d3.schemePurples"
+    Reds = "d3.schemeReds"
+
+    # Sequential Multi-Hue
+    BuGn = "d3.schemeBuGn"
+    BuPu = "d3.schemeBuPu"
+    GnBu = "d3.schemeGnBu"
+    OrRd = "d3.schemeOrRd"
+    PuBuGn = "d3.schemePuBuGn"
+    PuBu = "d3.schemePuBu"
+    PuRd = "d3.schemePuRd"
+    RdPu = "d3.schemeRdPu"
+    YlGnBu = "d3.schemeYlGnBu"
+    YlGn = "d3.schemeYlGn"
+    YlOrBr = "d3.schemeYlOrBr"
+    YlOrRd = "d3.schemeYlOrRd"
+
+    def __init__(self, val):
+        exclude = (
+            "Category10", "Accent", "Dark2", "Paired",
+            "Pastel1", "Pastel2", "Set1", "Set2", "Set3",
+            "Tableau10"
+        )
+
+        num = val if isinstance(val, int) else len(val)
+
+        for attr, val in self.__dict__.items():
+            if not attr.startswith("__") and attr not in exclude:
+                self.__dict__[attr] = f"{val}[{num}]"
+
+
+class Chord:
     template_url = "https://shahinrostami.com/assets/chord/chord.tmpl"
     template = urllib.request.urlopen(template_url).read()
 
@@ -63,9 +123,8 @@ class Chord(object):
 
     def to_html(self, filename="out.html"):
         self.render_html()
-        file = open(filename, "w")
-        file.write(self.html)
-        file.close()
+        with open(filename, "w") as file:
+            file.write(self.html)
 
     """Outputs the generated HTML to a Jupyter Notebook output cell."""
 


### PR DESCRIPTION
This adds ColorScheme, which includes all supported color schemes as ColorScheme.name, and has a constructor which will change the color scheme strings as needed. This is intended to help discovery, (eg. IDE will show available colors, or you can look in `__init__.py` instead of going to d3 documentation, which won't specify that d3.scheme____ is required), and ensure that the user knows why their color choice failed.

```
>>> ColorScheme(5).Blues
d3.schemeBlues[5]
```

It also checks that d3 supports the given value of k (length) for the given color scheme, and raises an error if that is not the case - which is helpful if you get a blank page and don't know why.

```
>>> ColorScheme(2).Blues
AttributeError: d3.schemeBlues requires 3 <= k <= 11 (got 2)
```

Additionally, you don't need to call len(), so it's as easy as 
```
>>> ColorScheme(["name1", "name2", "name3"]).Blues
d3.schemeBlues[3]
```

The following blocks show equivalent usages.
```
Chord(matrix, names, colors=f"d3.schemePuRd[{len(names)}]").show()
Chord(matrix, names, colors=ColorScheme(names).PuRd).show()
```

```
Chord(matrix, names, colors="d3.schemeSet3").show()
Chord(matrix, names, colors=ColorScheme.Set3).show()
```
